### PR TITLE
Add Chelmsford 2016 general

### DIFF
--- a/2016/20161108__ma__general__chelmsford__precinct.csv
+++ b/2016/20161108__ma__general__chelmsford__precinct.csv
@@ -1,206 +1,206 @@
-county,town,precinct,office,district,party,candidate,votes
-Middlesex,Chelmsford,1,President,,Democratic,CLINTON and KAINE,1167
-Middlesex,Chelmsford,2,President,,Democratic,CLINTON and KAINE,1133
-Middlesex,Chelmsford,3,President,,Democratic,CLINTON and KAINE,1108
-Middlesex,Chelmsford,4,President,,Democratic,CLINTON and KAINE,1048
-Middlesex,Chelmsford,5,President,,Democratic,CLINTON and KAINE,1201
-Middlesex,Chelmsford,6,President,,Democratic,CLINTON and KAINE,1261
-Middlesex,Chelmsford,7,President,,Democratic,CLINTON and KAINE,1292
-Middlesex,Chelmsford,8,President,,Democratic,CLINTON and KAINE,1239
-Middlesex,Chelmsford,9,President,,Democratic,CLINTON and KAINE,1256
-Middlesex,Chelmsford,TOTAL,President,,Democratic,CLINTON and KAINE,10705
-Middlesex,Chelmsford,1,President,,Libertarian,JOHNSON and WELD,116
-Middlesex,Chelmsford,2,President,,Libertarian,JOHNSON and WELD,109
-Middlesex,Chelmsford,3,President,,Libertarian,JOHNSON and WELD,110
-Middlesex,Chelmsford,4,President,,Libertarian,JOHNSON and WELD,79
-Middlesex,Chelmsford,5,President,,Libertarian,JOHNSON and WELD,143
-Middlesex,Chelmsford,6,President,,Libertarian,JOHNSON and WELD,137
-Middlesex,Chelmsford,7,President,,Libertarian,JOHNSON and WELD,155
-Middlesex,Chelmsford,8,President,,Libertarian,JOHNSON and WELD,108
-Middlesex,Chelmsford,9,President,,Libertarian,JOHNSON and WELD,136
-Middlesex,Chelmsford,TOTAL,President,,Libertarian,JOHNSON and WELD,1093
-Middlesex,Chelmsford,1,President,,Green-Rainbow,STEIN and BARAKA,32
-Middlesex,Chelmsford,2,President,,Green-Rainbow,STEIN and BARAKA,36
-Middlesex,Chelmsford,3,President,,Green-Rainbow,STEIN and BARAKA,24
-Middlesex,Chelmsford,4,President,,Green-Rainbow,STEIN and BARAKA,23
-Middlesex,Chelmsford,5,President,,Green-Rainbow,STEIN and BARAKA,32
-Middlesex,Chelmsford,6,President,,Green-Rainbow,STEIN and BARAKA,18
-Middlesex,Chelmsford,7,President,,Green-Rainbow,STEIN and BARAKA,29
-Middlesex,Chelmsford,8,President,,Green-Rainbow,STEIN and BARAKA,16
-Middlesex,Chelmsford,9,President,,Green-Rainbow,STEIN and BARAKA,27
-Middlesex,Chelmsford,TOTAL,President,,Green-Rainbow,STEIN and BARAKA,237
-Middlesex,Chelmsford,1,President,,Republican,TRUMP and PENCE,822
-Middlesex,Chelmsford,2,President,,Republican,TRUMP and PENCE,689
-Middlesex,Chelmsford,3,President,,Republican,TRUMP and PENCE,974
-Middlesex,Chelmsford,4,President,,Republican,TRUMP and PENCE,832
-Middlesex,Chelmsford,5,President,,Republican,TRUMP and PENCE,799
-Middlesex,Chelmsford,6,President,,Republican,TRUMP and PENCE,884
-Middlesex,Chelmsford,7,President,,Republican,TRUMP and PENCE,934
-Middlesex,Chelmsford,8,President,,Republican,TRUMP and PENCE,818
-Middlesex,Chelmsford,9,President,,Republican,TRUMP and PENCE,909
-Middlesex,Chelmsford,TOTAL,President,,Republican,TRUMP and PENCE,7661
-Middlesex,Chelmsford,1,President,,,All Others,52
-Middlesex,Chelmsford,2,President,,,All Others,33
-Middlesex,Chelmsford,3,President,,,All Others,42
-Middlesex,Chelmsford,4,President,,,All Others,42
-Middlesex,Chelmsford,5,President,,,All Others,48
-Middlesex,Chelmsford,6,President,,,All Others,50
-Middlesex,Chelmsford,7,President,,,All Others,53
-Middlesex,Chelmsford,8,President,,,All Others,48
-Middlesex,Chelmsford,9,President,,,All Others,77
-Middlesex,Chelmsford,TOTAL,President,,,All Others,445
-Middlesex,Chelmsford,1,President,,,Blanks,32
-Middlesex,Chelmsford,2,President,,,Blanks,29
-Middlesex,Chelmsford,3,President,,,Blanks,40
-Middlesex,Chelmsford,4,President,,,Blanks,34
-Middlesex,Chelmsford,5,President,,,Blanks,21
-Middlesex,Chelmsford,6,President,,,Blanks,47
-Middlesex,Chelmsford,7,President,,,Blanks,26
-Middlesex,Chelmsford,8,President,,,Blanks,34
-Middlesex,Chelmsford,9,President,,,Blanks,38
-Middlesex,Chelmsford,TOTAL,President,,,Blanks,301
-Middlesex,Chelmsford,1,U.S. House,3,Democratic,NICOLA S. TSONGAS,1357
-Middlesex,Chelmsford,2,U.S. House,3,Democratic,NICOLA S. TSONGAS,1381
-Middlesex,Chelmsford,3,U.S. House,3,Democratic,NICOLA S. TSONGAS,1401
-Middlesex,Chelmsford,4,U.S. House,3,Democratic,NICOLA S. TSONGAS,1302
-Middlesex,Chelmsford,5,U.S. House,3,Democratic,NICOLA S. TSONGAS,1416
-Middlesex,Chelmsford,6,U.S. House,3,Democratic,NICOLA S. TSONGAS,1532
-Middlesex,Chelmsford,7,U.S. House,3,Democratic,NICOLA S. TSONGAS,1526
-Middlesex,Chelmsford,8,U.S. House,3,Democratic,NICOLA S. TSONGAS,1461
-Middlesex,Chelmsford,9,U.S. House,3,Democratic,NICOLA S. TSONGAS,1468
-Middlesex,Chelmsford,TOTAL,U.S. House,3,Democratic,NICOLA S. TSONGAS,12844
-Middlesex,Chelmsford,1,U.S. House,3,Republican,ANN WOFFORD,783
-Middlesex,Chelmsford,2,U.S. House,3,Republican,ANN WOFFORD,585
-Middlesex,Chelmsford,3,U.S. House,3,Republican,ANN WOFFORD,805
-Middlesex,Chelmsford,4,U.S. House,3,Republican,ANN WOFFORD,671
-Middlesex,Chelmsford,5,U.S. House,3,Republican,ANN WOFFORD,745
-Middlesex,Chelmsford,6,U.S. House,3,Republican,ANN WOFFORD,770
-Middlesex,Chelmsford,7,U.S. House,3,Republican,ANN WOFFORD,898
-Middlesex,Chelmsford,8,U.S. House,3,Republican,ANN WOFFORD,723
-Middlesex,Chelmsford,9,U.S. House,3,Republican,ANN WOFFORD,861
-Middlesex,Chelmsford,TOTAL,U.S. House,3,Republican,ANN WOFFORD,6821
-Middlesex,Chelmsford,1,U.S. House,3,,All Others,0
-Middlesex,Chelmsford,2,U.S. House,3,,All Others,6
-Middlesex,Chelmsford,3,U.S. House,3,,All Others,0
-Middlesex,Chelmsford,4,U.S. House,3,,All Others,2
-Middlesex,Chelmsford,5,U.S. House,3,,All Others,2
-Middlesex,Chelmsford,6,U.S. House,3,,All Others,2
-Middlesex,Chelmsford,7,U.S. House,3,,All Others,3
-Middlesex,Chelmsford,8,U.S. House,3,,All Others,2
-Middlesex,Chelmsford,9,U.S. House,3,,All Others,5
-Middlesex,Chelmsford,TOTAL,U.S. House,3,,All Others,22
-Middlesex,Chelmsford,1,U.S. House,3,,Blanks,81
-Middlesex,Chelmsford,2,U.S. House,3,,Blanks,77
-Middlesex,Chelmsford,3,U.S. House,3,,Blanks,92
-Middlesex,Chelmsford,4,U.S. House,3,,Blanks,83
-Middlesex,Chelmsford,5,U.S. House,3,,Blanks,81
-Middlesex,Chelmsford,6,U.S. House,3,,Blanks,93
-Middlesex,Chelmsford,7,U.S. House,3,,Blanks,62
-Middlesex,Chelmsford,8,U.S. House,3,,Blanks,77
-Middlesex,Chelmsford,9,U.S. House,3,,Blanks,109
-Middlesex,Chelmsford,TOTAL,U.S. House,3,,Blanks,755
-Middlesex,Chelmsford,1,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1488
-Middlesex,Chelmsford,2,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1478
-Middlesex,Chelmsford,3,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1574
-Middlesex,Chelmsford,4,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1428
-Middlesex,Chelmsford,5,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1526
-Middlesex,Chelmsford,6,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1639
-Middlesex,Chelmsford,7,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1683
-Middlesex,Chelmsford,8,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1546
-Middlesex,Chelmsford,9,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1612
-Middlesex,Chelmsford,TOTAL,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,13974
-Middlesex,Chelmsford,1,Councillor,3,,All Others,27
-Middlesex,Chelmsford,2,Councillor,3,,All Others,18
-Middlesex,Chelmsford,3,Councillor,3,,All Others,28
-Middlesex,Chelmsford,4,Councillor,3,,All Others,31
-Middlesex,Chelmsford,5,Councillor,3,,All Others,29
-Middlesex,Chelmsford,6,Councillor,3,,All Others,34
-Middlesex,Chelmsford,7,Councillor,3,,All Others,24
-Middlesex,Chelmsford,8,Councillor,3,,All Others,15
-Middlesex,Chelmsford,9,Councillor,3,,All Others,34
-Middlesex,Chelmsford,TOTAL,Councillor,3,,All Others,240
-Middlesex,Chelmsford,1,Councillor,3,,Blanks,706
-Middlesex,Chelmsford,2,Councillor,3,,Blanks,533
-Middlesex,Chelmsford,3,Councillor,3,,Blanks,698
-Middlesex,Chelmsford,4,Councillor,3,,Blanks,599
-Middlesex,Chelmsford,5,Councillor,3,,Blanks,689
-Middlesex,Chelmsford,6,Councillor,3,,Blanks,724
-Middlesex,Chelmsford,7,Councillor,3,,Blanks,782
-Middlesex,Chelmsford,8,Councillor,3,,Blanks,702
-Middlesex,Chelmsford,9,Councillor,3,,Blanks,797
-Middlesex,Chelmsford,TOTAL,Councillor,3,,Blanks,6228
-Middlesex,Chelmsford,1,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1372
-Middlesex,Chelmsford,2,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1394
-Middlesex,Chelmsford,3,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1480
-Middlesex,Chelmsford,4,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1315
-Middlesex,Chelmsford,5,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1377
-Middlesex,Chelmsford,6,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1530
-Middlesex,Chelmsford,7,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1555
-Middlesex,Chelmsford,8,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1435
-Middlesex,Chelmsford,9,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1448
-Middlesex,Chelmsford,TOTAL,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,12906
-Middlesex,Chelmsford,1,State Senate,3rd Middlesex,,All Others,2
-Middlesex,Chelmsford,2,State Senate,3rd Middlesex,,All Others,13
-Middlesex,Chelmsford,3,State Senate,3rd Middlesex,,All Others,26
-Middlesex,Chelmsford,4,State Senate,3rd Middlesex,,All Others,30
-Middlesex,Chelmsford,5,State Senate,3rd Middlesex,,All Others,33
-Middlesex,Chelmsford,6,State Senate,3rd Middlesex,,All Others,29
-Middlesex,Chelmsford,7,State Senate,3rd Middlesex,,All Others,26
-Middlesex,Chelmsford,8,State Senate,3rd Middlesex,,All Others,16
-Middlesex,Chelmsford,9,State Senate,3rd Middlesex,,All Others,29
-Middlesex,Chelmsford,TOTAL,State Senate,3rd Middlesex,,All Others,204
-Middlesex,Chelmsford,1,State Senate,3rd Middlesex,,Blanks,847
-Middlesex,Chelmsford,2,State Senate,3rd Middlesex,,Blanks,622
-Middlesex,Chelmsford,3,State Senate,3rd Middlesex,,Blanks,792
-Middlesex,Chelmsford,4,State Senate,3rd Middlesex,,Blanks,713
-Middlesex,Chelmsford,5,State Senate,3rd Middlesex,,Blanks,834
-Middlesex,Chelmsford,6,State Senate,3rd Middlesex,,Blanks,838
-Middlesex,Chelmsford,7,State Senate,3rd Middlesex,,Blanks,908
-Middlesex,Chelmsford,8,State Senate,3rd Middlesex,,Blanks,812
-Middlesex,Chelmsford,9,State Senate,3rd Middlesex,,Blanks,966
-Middlesex,Chelmsford,TOTAL,State Senate,3rd Middlesex,,Blanks,7332
-Middlesex,Chelmsford,1,State House,14th Middlesex,Democratic,COREY ATKINS,1027
-Middlesex,Chelmsford,9,State House,14th Middlesex,Democratic,COREY ATKINS,1113
-Middlesex,Chelmsford,TOTAL,State House,14th Middlesex,Democratic,COREY ATKINS,2140
-Middlesex,Chelmsford,1,State House,14th Middlesex,Republican,HELEN BRADY,948
-Middlesex,Chelmsford,9,State House,14th Middlesex,Republican,HELEN BRADY,1070
-Middlesex,Chelmsford,TOTAL,State House,14th Middlesex,Republican,HELEN BRADY,2018
-Middlesex,Chelmsford,1,State House,14th Middlesex,Green-Rainbow,DANIEL L. FACTOR,93
-Middlesex,Chelmsford,9,State House,14th Middlesex,Green-Rainbow,DANIEL L. FACTOR,90
-Middlesex,Chelmsford,TOTAL,State House,14th Middlesex,Green-Rainbow,DANIEL L. FACTOR,183
-Middlesex,Chelmsford,1,State House,14th Middlesex,,All Others,0
-Middlesex,Chelmsford,9,State House,14th Middlesex,,All Others,9
-Middlesex,Chelmsford,TOTAL,State House,14th Middlesex,,All Others,9
-Middlesex,Chelmsford,1,State House,14th Middlesex,,Blanks,153
-Middlesex,Chelmsford,9,State House,14th Middlesex,,Blanks,161
-Middlesex,Chelmsford,TOTAL,State House,14th Middlesex,,Blanks,314
-Middlesex,Chelmsford,2,State House,16th Middlesex,Democratic,THOMAS A. GOLDEN, JR.,1518
-Middlesex,Chelmsford,3,State House,16th Middlesex,Democratic,THOMAS A. GOLDEN, JR.,1626
-Middlesex,Chelmsford,6,State House,16th Middlesex,Democratic,THOMAS A. GOLDEN, JR.,1728
-Middlesex,Chelmsford,TOTAL,State House,16th Middlesex,Democratic,THOMAS A. GOLDEN, JR.,4872
-Middlesex,Chelmsford,2,State House,16th Middlesex,,All Others,17
-Middlesex,Chelmsford,3,State House,16th Middlesex,,All Others,27
-Middlesex,Chelmsford,6,State House,16th Middlesex,,All Others,32
-Middlesex,Chelmsford,TOTAL,State House,16th Middlesex,,All Others,78
-Middlesex,Chelmsford,2,State House,16th Middlesex,,Blanks,494
-Middlesex,Chelmsford,3,State House,16th Middlesex,,Blanks,645
-Middlesex,Chelmsford,6,State House,16th Middlesex,,Blanks,637
-Middlesex,Chelmsford,TOTAL,State House,16th Middlesex,,Blanks,1776
-Middlesex,Chelmsford,4,State House,17th Middlesex,Democratic,DAVID M. NANGLE,1474
-Middlesex,Chelmsford,TOTAL,State House,17th Middlesex,Democratic,DAVID M. NANGLE,1474
-Middlesex,Chelmsford,4,State House,17th Middlesex,,All Others,26
-Middlesex,Chelmsford,TOTAL,State House,17th Middlesex,,All Others,26
-Middlesex,Chelmsford,4,State House,17th Middlesex,,Blanks,558
-Middlesex,Chelmsford,TOTAL,State House,17th Middlesex,,Blanks,558
-Middlesex,Chelmsford,5,State House,2nd Middlesex,Democratic,JAMES ARCIERO,1557
-Middlesex,Chelmsford,7,State House,2nd Middlesex,Democratic,JAMES ARCIERO,1706
-Middlesex,Chelmsford,8,State House,2nd Middlesex,Democratic,JAMES ARCIERO,1586
-Middlesex,Chelmsford,TOTAL,State House,2nd Middlesex,Democratic,JAMES ARCIERO,4849
-Middlesex,Chelmsford,5,State House,2nd Middlesex,,All Others,35
-Middlesex,Chelmsford,7,State House,2nd Middlesex,,All Others,24
-Middlesex,Chelmsford,8,State House,2nd Middlesex,,All Others,9
-Middlesex,Chelmsford,TOTAL,State House,2nd Middlesex,,All Others,68
-Middlesex,Chelmsford,5,State House,2nd Middlesex,,Blanks,652
-Middlesex,Chelmsford,7,State House,2nd Middlesex,,Blanks,759
-Middlesex,Chelmsford,8,State House,2nd Middlesex,,Blanks,668
-Middlesex,Chelmsford,TOTAL,State House,2nd Middlesex,,Blanks,2079
+"county","town","precinct","office","district","party","candidate","votes"
+"Middlesex","Chelmsford","1","President","","Democratic","CLINTON and KAINE","1167"
+"Middlesex","Chelmsford","2","President","","Democratic","CLINTON and KAINE","1133"
+"Middlesex","Chelmsford","3","President","","Democratic","CLINTON and KAINE","1108"
+"Middlesex","Chelmsford","4","President","","Democratic","CLINTON and KAINE","1048"
+"Middlesex","Chelmsford","5","President","","Democratic","CLINTON and KAINE","1201"
+"Middlesex","Chelmsford","6","President","","Democratic","CLINTON and KAINE","1261"
+"Middlesex","Chelmsford","7","President","","Democratic","CLINTON and KAINE","1292"
+"Middlesex","Chelmsford","8","President","","Democratic","CLINTON and KAINE","1239"
+"Middlesex","Chelmsford","9","President","","Democratic","CLINTON and KAINE","1256"
+"Middlesex","Chelmsford","TOTAL","President","","Democratic","CLINTON and KAINE","10705"
+"Middlesex","Chelmsford","1","President","","Libertarian","JOHNSON and WELD","116"
+"Middlesex","Chelmsford","2","President","","Libertarian","JOHNSON and WELD","109"
+"Middlesex","Chelmsford","3","President","","Libertarian","JOHNSON and WELD","110"
+"Middlesex","Chelmsford","4","President","","Libertarian","JOHNSON and WELD","79"
+"Middlesex","Chelmsford","5","President","","Libertarian","JOHNSON and WELD","143"
+"Middlesex","Chelmsford","6","President","","Libertarian","JOHNSON and WELD","137"
+"Middlesex","Chelmsford","7","President","","Libertarian","JOHNSON and WELD","155"
+"Middlesex","Chelmsford","8","President","","Libertarian","JOHNSON and WELD","108"
+"Middlesex","Chelmsford","9","President","","Libertarian","JOHNSON and WELD","136"
+"Middlesex","Chelmsford","TOTAL","President","","Libertarian","JOHNSON and WELD","1093"
+"Middlesex","Chelmsford","1","President","","Green-Rainbow","STEIN and BARAKA","32"
+"Middlesex","Chelmsford","2","President","","Green-Rainbow","STEIN and BARAKA","36"
+"Middlesex","Chelmsford","3","President","","Green-Rainbow","STEIN and BARAKA","24"
+"Middlesex","Chelmsford","4","President","","Green-Rainbow","STEIN and BARAKA","23"
+"Middlesex","Chelmsford","5","President","","Green-Rainbow","STEIN and BARAKA","32"
+"Middlesex","Chelmsford","6","President","","Green-Rainbow","STEIN and BARAKA","18"
+"Middlesex","Chelmsford","7","President","","Green-Rainbow","STEIN and BARAKA","29"
+"Middlesex","Chelmsford","8","President","","Green-Rainbow","STEIN and BARAKA","16"
+"Middlesex","Chelmsford","9","President","","Green-Rainbow","STEIN and BARAKA","27"
+"Middlesex","Chelmsford","TOTAL","President","","Green-Rainbow","STEIN and BARAKA","237"
+"Middlesex","Chelmsford","1","President","","Republican","TRUMP and PENCE","822"
+"Middlesex","Chelmsford","2","President","","Republican","TRUMP and PENCE","689"
+"Middlesex","Chelmsford","3","President","","Republican","TRUMP and PENCE","974"
+"Middlesex","Chelmsford","4","President","","Republican","TRUMP and PENCE","832"
+"Middlesex","Chelmsford","5","President","","Republican","TRUMP and PENCE","799"
+"Middlesex","Chelmsford","6","President","","Republican","TRUMP and PENCE","884"
+"Middlesex","Chelmsford","7","President","","Republican","TRUMP and PENCE","934"
+"Middlesex","Chelmsford","8","President","","Republican","TRUMP and PENCE","818"
+"Middlesex","Chelmsford","9","President","","Republican","TRUMP and PENCE","909"
+"Middlesex","Chelmsford","TOTAL","President","","Republican","TRUMP and PENCE","7661"
+"Middlesex","Chelmsford","1","President","","","All Others","52"
+"Middlesex","Chelmsford","2","President","","","All Others","33"
+"Middlesex","Chelmsford","3","President","","","All Others","42"
+"Middlesex","Chelmsford","4","President","","","All Others","42"
+"Middlesex","Chelmsford","5","President","","","All Others","48"
+"Middlesex","Chelmsford","6","President","","","All Others","50"
+"Middlesex","Chelmsford","7","President","","","All Others","53"
+"Middlesex","Chelmsford","8","President","","","All Others","48"
+"Middlesex","Chelmsford","9","President","","","All Others","77"
+"Middlesex","Chelmsford","TOTAL","President","","","All Others","445"
+"Middlesex","Chelmsford","1","President","","","Blanks","32"
+"Middlesex","Chelmsford","2","President","","","Blanks","29"
+"Middlesex","Chelmsford","3","President","","","Blanks","40"
+"Middlesex","Chelmsford","4","President","","","Blanks","34"
+"Middlesex","Chelmsford","5","President","","","Blanks","21"
+"Middlesex","Chelmsford","6","President","","","Blanks","47"
+"Middlesex","Chelmsford","7","President","","","Blanks","26"
+"Middlesex","Chelmsford","8","President","","","Blanks","34"
+"Middlesex","Chelmsford","9","President","","","Blanks","38"
+"Middlesex","Chelmsford","TOTAL","President","","","Blanks","301"
+"Middlesex","Chelmsford","1","U.S. House","3","Democratic","NICOLA S. TSONGAS","1357"
+"Middlesex","Chelmsford","2","U.S. House","3","Democratic","NICOLA S. TSONGAS","1381"
+"Middlesex","Chelmsford","3","U.S. House","3","Democratic","NICOLA S. TSONGAS","1401"
+"Middlesex","Chelmsford","4","U.S. House","3","Democratic","NICOLA S. TSONGAS","1302"
+"Middlesex","Chelmsford","5","U.S. House","3","Democratic","NICOLA S. TSONGAS","1416"
+"Middlesex","Chelmsford","6","U.S. House","3","Democratic","NICOLA S. TSONGAS","1532"
+"Middlesex","Chelmsford","7","U.S. House","3","Democratic","NICOLA S. TSONGAS","1526"
+"Middlesex","Chelmsford","8","U.S. House","3","Democratic","NICOLA S. TSONGAS","1461"
+"Middlesex","Chelmsford","9","U.S. House","3","Democratic","NICOLA S. TSONGAS","1468"
+"Middlesex","Chelmsford","TOTAL","U.S. House","3","Democratic","NICOLA S. TSONGAS","12844"
+"Middlesex","Chelmsford","1","U.S. House","3","Republican","ANN WOFFORD","783"
+"Middlesex","Chelmsford","2","U.S. House","3","Republican","ANN WOFFORD","585"
+"Middlesex","Chelmsford","3","U.S. House","3","Republican","ANN WOFFORD","805"
+"Middlesex","Chelmsford","4","U.S. House","3","Republican","ANN WOFFORD","671"
+"Middlesex","Chelmsford","5","U.S. House","3","Republican","ANN WOFFORD","745"
+"Middlesex","Chelmsford","6","U.S. House","3","Republican","ANN WOFFORD","770"
+"Middlesex","Chelmsford","7","U.S. House","3","Republican","ANN WOFFORD","898"
+"Middlesex","Chelmsford","8","U.S. House","3","Republican","ANN WOFFORD","723"
+"Middlesex","Chelmsford","9","U.S. House","3","Republican","ANN WOFFORD","861"
+"Middlesex","Chelmsford","TOTAL","U.S. House","3","Republican","ANN WOFFORD","6821"
+"Middlesex","Chelmsford","1","U.S. House","3","","All Others","0"
+"Middlesex","Chelmsford","2","U.S. House","3","","All Others","6"
+"Middlesex","Chelmsford","3","U.S. House","3","","All Others","0"
+"Middlesex","Chelmsford","4","U.S. House","3","","All Others","2"
+"Middlesex","Chelmsford","5","U.S. House","3","","All Others","2"
+"Middlesex","Chelmsford","6","U.S. House","3","","All Others","2"
+"Middlesex","Chelmsford","7","U.S. House","3","","All Others","3"
+"Middlesex","Chelmsford","8","U.S. House","3","","All Others","2"
+"Middlesex","Chelmsford","9","U.S. House","3","","All Others","5"
+"Middlesex","Chelmsford","TOTAL","U.S. House","3","","All Others","22"
+"Middlesex","Chelmsford","1","U.S. House","3","","Blanks","81"
+"Middlesex","Chelmsford","2","U.S. House","3","","Blanks","77"
+"Middlesex","Chelmsford","3","U.S. House","3","","Blanks","92"
+"Middlesex","Chelmsford","4","U.S. House","3","","Blanks","83"
+"Middlesex","Chelmsford","5","U.S. House","3","","Blanks","81"
+"Middlesex","Chelmsford","6","U.S. House","3","","Blanks","93"
+"Middlesex","Chelmsford","7","U.S. House","3","","Blanks","62"
+"Middlesex","Chelmsford","8","U.S. House","3","","Blanks","77"
+"Middlesex","Chelmsford","9","U.S. House","3","","Blanks","109"
+"Middlesex","Chelmsford","TOTAL","U.S. House","3","","Blanks","755"
+"Middlesex","Chelmsford","1","Councillor","3","Democratic","MARILYN M. PETITTO DEVANEY","1488"
+"Middlesex","Chelmsford","2","Councillor","3","Democratic","MARILYN M. PETITTO DEVANEY","1478"
+"Middlesex","Chelmsford","3","Councillor","3","Democratic","MARILYN M. PETITTO DEVANEY","1574"
+"Middlesex","Chelmsford","4","Councillor","3","Democratic","MARILYN M. PETITTO DEVANEY","1428"
+"Middlesex","Chelmsford","5","Councillor","3","Democratic","MARILYN M. PETITTO DEVANEY","1526"
+"Middlesex","Chelmsford","6","Councillor","3","Democratic","MARILYN M. PETITTO DEVANEY","1639"
+"Middlesex","Chelmsford","7","Councillor","3","Democratic","MARILYN M. PETITTO DEVANEY","1683"
+"Middlesex","Chelmsford","8","Councillor","3","Democratic","MARILYN M. PETITTO DEVANEY","1546"
+"Middlesex","Chelmsford","9","Councillor","3","Democratic","MARILYN M. PETITTO DEVANEY","1612"
+"Middlesex","Chelmsford","TOTAL","Councillor","3","Democratic","MARILYN M. PETITTO DEVANEY","13974"
+"Middlesex","Chelmsford","1","Councillor","3","","All Others","27"
+"Middlesex","Chelmsford","2","Councillor","3","","All Others","18"
+"Middlesex","Chelmsford","3","Councillor","3","","All Others","28"
+"Middlesex","Chelmsford","4","Councillor","3","","All Others","31"
+"Middlesex","Chelmsford","5","Councillor","3","","All Others","29"
+"Middlesex","Chelmsford","6","Councillor","3","","All Others","34"
+"Middlesex","Chelmsford","7","Councillor","3","","All Others","24"
+"Middlesex","Chelmsford","8","Councillor","3","","All Others","15"
+"Middlesex","Chelmsford","9","Councillor","3","","All Others","34"
+"Middlesex","Chelmsford","TOTAL","Councillor","3","","All Others","240"
+"Middlesex","Chelmsford","1","Councillor","3","","Blanks","706"
+"Middlesex","Chelmsford","2","Councillor","3","","Blanks","533"
+"Middlesex","Chelmsford","3","Councillor","3","","Blanks","698"
+"Middlesex","Chelmsford","4","Councillor","3","","Blanks","599"
+"Middlesex","Chelmsford","5","Councillor","3","","Blanks","689"
+"Middlesex","Chelmsford","6","Councillor","3","","Blanks","724"
+"Middlesex","Chelmsford","7","Councillor","3","","Blanks","782"
+"Middlesex","Chelmsford","8","Councillor","3","","Blanks","702"
+"Middlesex","Chelmsford","9","Councillor","3","","Blanks","797"
+"Middlesex","Chelmsford","TOTAL","Councillor","3","","Blanks","6228"
+"Middlesex","Chelmsford","1","State Senate","3rd Middlesex","Democratic","MICHAEL J. BARRETT","1372"
+"Middlesex","Chelmsford","2","State Senate","3rd Middlesex","Democratic","MICHAEL J. BARRETT","1394"
+"Middlesex","Chelmsford","3","State Senate","3rd Middlesex","Democratic","MICHAEL J. BARRETT","1480"
+"Middlesex","Chelmsford","4","State Senate","3rd Middlesex","Democratic","MICHAEL J. BARRETT","1315"
+"Middlesex","Chelmsford","5","State Senate","3rd Middlesex","Democratic","MICHAEL J. BARRETT","1377"
+"Middlesex","Chelmsford","6","State Senate","3rd Middlesex","Democratic","MICHAEL J. BARRETT","1530"
+"Middlesex","Chelmsford","7","State Senate","3rd Middlesex","Democratic","MICHAEL J. BARRETT","1555"
+"Middlesex","Chelmsford","8","State Senate","3rd Middlesex","Democratic","MICHAEL J. BARRETT","1435"
+"Middlesex","Chelmsford","9","State Senate","3rd Middlesex","Democratic","MICHAEL J. BARRETT","1448"
+"Middlesex","Chelmsford","TOTAL","State Senate","3rd Middlesex","Democratic","MICHAEL J. BARRETT","12906"
+"Middlesex","Chelmsford","1","State Senate","3rd Middlesex","","All Others","2"
+"Middlesex","Chelmsford","2","State Senate","3rd Middlesex","","All Others","13"
+"Middlesex","Chelmsford","3","State Senate","3rd Middlesex","","All Others","26"
+"Middlesex","Chelmsford","4","State Senate","3rd Middlesex","","All Others","30"
+"Middlesex","Chelmsford","5","State Senate","3rd Middlesex","","All Others","33"
+"Middlesex","Chelmsford","6","State Senate","3rd Middlesex","","All Others","29"
+"Middlesex","Chelmsford","7","State Senate","3rd Middlesex","","All Others","26"
+"Middlesex","Chelmsford","8","State Senate","3rd Middlesex","","All Others","16"
+"Middlesex","Chelmsford","9","State Senate","3rd Middlesex","","All Others","29"
+"Middlesex","Chelmsford","TOTAL","State Senate","3rd Middlesex","","All Others","204"
+"Middlesex","Chelmsford","1","State Senate","3rd Middlesex","","Blanks","847"
+"Middlesex","Chelmsford","2","State Senate","3rd Middlesex","","Blanks","622"
+"Middlesex","Chelmsford","3","State Senate","3rd Middlesex","","Blanks","792"
+"Middlesex","Chelmsford","4","State Senate","3rd Middlesex","","Blanks","713"
+"Middlesex","Chelmsford","5","State Senate","3rd Middlesex","","Blanks","834"
+"Middlesex","Chelmsford","6","State Senate","3rd Middlesex","","Blanks","838"
+"Middlesex","Chelmsford","7","State Senate","3rd Middlesex","","Blanks","908"
+"Middlesex","Chelmsford","8","State Senate","3rd Middlesex","","Blanks","812"
+"Middlesex","Chelmsford","9","State Senate","3rd Middlesex","","Blanks","966"
+"Middlesex","Chelmsford","TOTAL","State Senate","3rd Middlesex","","Blanks","7332"
+"Middlesex","Chelmsford","1","State House","14th Middlesex","Democratic","COREY ATKINS","1027"
+"Middlesex","Chelmsford","9","State House","14th Middlesex","Democratic","COREY ATKINS","1113"
+"Middlesex","Chelmsford","TOTAL","State House","14th Middlesex","Democratic","COREY ATKINS","2140"
+"Middlesex","Chelmsford","1","State House","14th Middlesex","Republican","HELEN BRADY","948"
+"Middlesex","Chelmsford","9","State House","14th Middlesex","Republican","HELEN BRADY","1070"
+"Middlesex","Chelmsford","TOTAL","State House","14th Middlesex","Republican","HELEN BRADY","2018"
+"Middlesex","Chelmsford","1","State House","14th Middlesex","Green-Rainbow","DANIEL L. FACTOR","93"
+"Middlesex","Chelmsford","9","State House","14th Middlesex","Green-Rainbow","DANIEL L. FACTOR","90"
+"Middlesex","Chelmsford","TOTAL","State House","14th Middlesex","Green-Rainbow","DANIEL L. FACTOR","183"
+"Middlesex","Chelmsford","1","State House","14th Middlesex","","All Others","0"
+"Middlesex","Chelmsford","9","State House","14th Middlesex","","All Others","9"
+"Middlesex","Chelmsford","TOTAL","State House","14th Middlesex","","All Others","9"
+"Middlesex","Chelmsford","1","State House","14th Middlesex","","Blanks","153"
+"Middlesex","Chelmsford","9","State House","14th Middlesex","","Blanks","161"
+"Middlesex","Chelmsford","TOTAL","State House","14th Middlesex","","Blanks","314"
+"Middlesex","Chelmsford","2","State House","16th Middlesex","Democratic","THOMAS A. GOLDEN, JR.","1518"
+"Middlesex","Chelmsford","3","State House","16th Middlesex","Democratic","THOMAS A. GOLDEN, JR.","1626"
+"Middlesex","Chelmsford","6","State House","16th Middlesex","Democratic","THOMAS A. GOLDEN, JR.","1728"
+"Middlesex","Chelmsford","TOTAL","State House","16th Middlesex","Democratic","THOMAS A. GOLDEN, JR.","4872"
+"Middlesex","Chelmsford","2","State House","16th Middlesex","","All Others","17"
+"Middlesex","Chelmsford","3","State House","16th Middlesex","","All Others","27"
+"Middlesex","Chelmsford","6","State House","16th Middlesex","","All Others","32"
+"Middlesex","Chelmsford","TOTAL","State House","16th Middlesex","","All Others","78"
+"Middlesex","Chelmsford","2","State House","16th Middlesex","","Blanks","494"
+"Middlesex","Chelmsford","3","State House","16th Middlesex","","Blanks","645"
+"Middlesex","Chelmsford","6","State House","16th Middlesex","","Blanks","637"
+"Middlesex","Chelmsford","TOTAL","State House","16th Middlesex","","Blanks","1776"
+"Middlesex","Chelmsford","4","State House","17th Middlesex","Democratic","DAVID M. NANGLE","1474"
+"Middlesex","Chelmsford","TOTAL","State House","17th Middlesex","Democratic","DAVID M. NANGLE","1474"
+"Middlesex","Chelmsford","4","State House","17th Middlesex","","All Others","26"
+"Middlesex","Chelmsford","TOTAL","State House","17th Middlesex","","All Others","26"
+"Middlesex","Chelmsford","4","State House","17th Middlesex","","Blanks","558"
+"Middlesex","Chelmsford","TOTAL","State House","17th Middlesex","","Blanks","558"
+"Middlesex","Chelmsford","5","State House","2nd Middlesex","Democratic","JAMES ARCIERO","1557"
+"Middlesex","Chelmsford","7","State House","2nd Middlesex","Democratic","JAMES ARCIERO","1706"
+"Middlesex","Chelmsford","8","State House","2nd Middlesex","Democratic","JAMES ARCIERO","1586"
+"Middlesex","Chelmsford","TOTAL","State House","2nd Middlesex","Democratic","JAMES ARCIERO","4849"
+"Middlesex","Chelmsford","5","State House","2nd Middlesex","","All Others","35"
+"Middlesex","Chelmsford","7","State House","2nd Middlesex","","All Others","24"
+"Middlesex","Chelmsford","8","State House","2nd Middlesex","","All Others","9"
+"Middlesex","Chelmsford","TOTAL","State House","2nd Middlesex","","All Others","68"
+"Middlesex","Chelmsford","5","State House","2nd Middlesex","","Blanks","652"
+"Middlesex","Chelmsford","7","State House","2nd Middlesex","","Blanks","759"
+"Middlesex","Chelmsford","8","State House","2nd Middlesex","","Blanks","668"
+"Middlesex","Chelmsford","TOTAL","State House","2nd Middlesex","","Blanks","2079"

--- a/2016/20161108__ma__general__chelmsford__precinct.csv
+++ b/2016/20161108__ma__general__chelmsford__precinct.csv
@@ -1,0 +1,206 @@
+county,town,precinct,office,district,party,candidate,votes
+Middlesex,Chelmsford,1,President,,Democratic,CLINTON and KAINE,1167
+Middlesex,Chelmsford,2,President,,Democratic,CLINTON and KAINE,1133
+Middlesex,Chelmsford,3,President,,Democratic,CLINTON and KAINE,1108
+Middlesex,Chelmsford,4,President,,Democratic,CLINTON and KAINE,1048
+Middlesex,Chelmsford,5,President,,Democratic,CLINTON and KAINE,1201
+Middlesex,Chelmsford,6,President,,Democratic,CLINTON and KAINE,1261
+Middlesex,Chelmsford,7,President,,Democratic,CLINTON and KAINE,1292
+Middlesex,Chelmsford,8,President,,Democratic,CLINTON and KAINE,1239
+Middlesex,Chelmsford,9,President,,Democratic,CLINTON and KAINE,1256
+Middlesex,Chelmsford,TOTAL,President,,Democratic,CLINTON and KAINE,10705
+Middlesex,Chelmsford,1,President,,Libertarian,JOHNSON and WELD,116
+Middlesex,Chelmsford,2,President,,Libertarian,JOHNSON and WELD,109
+Middlesex,Chelmsford,3,President,,Libertarian,JOHNSON and WELD,110
+Middlesex,Chelmsford,4,President,,Libertarian,JOHNSON and WELD,79
+Middlesex,Chelmsford,5,President,,Libertarian,JOHNSON and WELD,143
+Middlesex,Chelmsford,6,President,,Libertarian,JOHNSON and WELD,137
+Middlesex,Chelmsford,7,President,,Libertarian,JOHNSON and WELD,155
+Middlesex,Chelmsford,8,President,,Libertarian,JOHNSON and WELD,108
+Middlesex,Chelmsford,9,President,,Libertarian,JOHNSON and WELD,136
+Middlesex,Chelmsford,TOTAL,President,,Libertarian,JOHNSON and WELD,1093
+Middlesex,Chelmsford,1,President,,Green-Rainbow,STEIN and BARAKA,32
+Middlesex,Chelmsford,2,President,,Green-Rainbow,STEIN and BARAKA,36
+Middlesex,Chelmsford,3,President,,Green-Rainbow,STEIN and BARAKA,24
+Middlesex,Chelmsford,4,President,,Green-Rainbow,STEIN and BARAKA,23
+Middlesex,Chelmsford,5,President,,Green-Rainbow,STEIN and BARAKA,32
+Middlesex,Chelmsford,6,President,,Green-Rainbow,STEIN and BARAKA,18
+Middlesex,Chelmsford,7,President,,Green-Rainbow,STEIN and BARAKA,29
+Middlesex,Chelmsford,8,President,,Green-Rainbow,STEIN and BARAKA,16
+Middlesex,Chelmsford,9,President,,Green-Rainbow,STEIN and BARAKA,27
+Middlesex,Chelmsford,TOTAL,President,,Green-Rainbow,STEIN and BARAKA,237
+Middlesex,Chelmsford,1,President,,Republican,TRUMP and PENCE,822
+Middlesex,Chelmsford,2,President,,Republican,TRUMP and PENCE,689
+Middlesex,Chelmsford,3,President,,Republican,TRUMP and PENCE,974
+Middlesex,Chelmsford,4,President,,Republican,TRUMP and PENCE,832
+Middlesex,Chelmsford,5,President,,Republican,TRUMP and PENCE,799
+Middlesex,Chelmsford,6,President,,Republican,TRUMP and PENCE,884
+Middlesex,Chelmsford,7,President,,Republican,TRUMP and PENCE,934
+Middlesex,Chelmsford,8,President,,Republican,TRUMP and PENCE,818
+Middlesex,Chelmsford,9,President,,Republican,TRUMP and PENCE,909
+Middlesex,Chelmsford,TOTAL,President,,Republican,TRUMP and PENCE,7661
+Middlesex,Chelmsford,1,President,,,All Others,52
+Middlesex,Chelmsford,2,President,,,All Others,33
+Middlesex,Chelmsford,3,President,,,All Others,42
+Middlesex,Chelmsford,4,President,,,All Others,42
+Middlesex,Chelmsford,5,President,,,All Others,48
+Middlesex,Chelmsford,6,President,,,All Others,50
+Middlesex,Chelmsford,7,President,,,All Others,53
+Middlesex,Chelmsford,8,President,,,All Others,48
+Middlesex,Chelmsford,9,President,,,All Others,77
+Middlesex,Chelmsford,TOTAL,President,,,All Others,445
+Middlesex,Chelmsford,1,President,,,Blanks,32
+Middlesex,Chelmsford,2,President,,,Blanks,29
+Middlesex,Chelmsford,3,President,,,Blanks,40
+Middlesex,Chelmsford,4,President,,,Blanks,34
+Middlesex,Chelmsford,5,President,,,Blanks,21
+Middlesex,Chelmsford,6,President,,,Blanks,47
+Middlesex,Chelmsford,7,President,,,Blanks,26
+Middlesex,Chelmsford,8,President,,,Blanks,34
+Middlesex,Chelmsford,9,President,,,Blanks,38
+Middlesex,Chelmsford,TOTAL,President,,,Blanks,301
+Middlesex,Chelmsford,1,U.S. House,3,Democratic,NICOLA S. TSONGAS,1357
+Middlesex,Chelmsford,2,U.S. House,3,Democratic,NICOLA S. TSONGAS,1381
+Middlesex,Chelmsford,3,U.S. House,3,Democratic,NICOLA S. TSONGAS,1401
+Middlesex,Chelmsford,4,U.S. House,3,Democratic,NICOLA S. TSONGAS,1302
+Middlesex,Chelmsford,5,U.S. House,3,Democratic,NICOLA S. TSONGAS,1416
+Middlesex,Chelmsford,6,U.S. House,3,Democratic,NICOLA S. TSONGAS,1532
+Middlesex,Chelmsford,7,U.S. House,3,Democratic,NICOLA S. TSONGAS,1526
+Middlesex,Chelmsford,8,U.S. House,3,Democratic,NICOLA S. TSONGAS,1461
+Middlesex,Chelmsford,9,U.S. House,3,Democratic,NICOLA S. TSONGAS,1468
+Middlesex,Chelmsford,TOTAL,U.S. House,3,Democratic,NICOLA S. TSONGAS,12844
+Middlesex,Chelmsford,1,U.S. House,3,Republican,ANN WOFFORD,783
+Middlesex,Chelmsford,2,U.S. House,3,Republican,ANN WOFFORD,585
+Middlesex,Chelmsford,3,U.S. House,3,Republican,ANN WOFFORD,805
+Middlesex,Chelmsford,4,U.S. House,3,Republican,ANN WOFFORD,671
+Middlesex,Chelmsford,5,U.S. House,3,Republican,ANN WOFFORD,745
+Middlesex,Chelmsford,6,U.S. House,3,Republican,ANN WOFFORD,770
+Middlesex,Chelmsford,7,U.S. House,3,Republican,ANN WOFFORD,898
+Middlesex,Chelmsford,8,U.S. House,3,Republican,ANN WOFFORD,723
+Middlesex,Chelmsford,9,U.S. House,3,Republican,ANN WOFFORD,861
+Middlesex,Chelmsford,TOTAL,U.S. House,3,Republican,ANN WOFFORD,6821
+Middlesex,Chelmsford,1,U.S. House,3,,All Others,0
+Middlesex,Chelmsford,2,U.S. House,3,,All Others,6
+Middlesex,Chelmsford,3,U.S. House,3,,All Others,0
+Middlesex,Chelmsford,4,U.S. House,3,,All Others,2
+Middlesex,Chelmsford,5,U.S. House,3,,All Others,2
+Middlesex,Chelmsford,6,U.S. House,3,,All Others,2
+Middlesex,Chelmsford,7,U.S. House,3,,All Others,3
+Middlesex,Chelmsford,8,U.S. House,3,,All Others,2
+Middlesex,Chelmsford,9,U.S. House,3,,All Others,5
+Middlesex,Chelmsford,TOTAL,U.S. House,3,,All Others,22
+Middlesex,Chelmsford,1,U.S. House,3,,Blanks,81
+Middlesex,Chelmsford,2,U.S. House,3,,Blanks,77
+Middlesex,Chelmsford,3,U.S. House,3,,Blanks,92
+Middlesex,Chelmsford,4,U.S. House,3,,Blanks,83
+Middlesex,Chelmsford,5,U.S. House,3,,Blanks,81
+Middlesex,Chelmsford,6,U.S. House,3,,Blanks,93
+Middlesex,Chelmsford,7,U.S. House,3,,Blanks,62
+Middlesex,Chelmsford,8,U.S. House,3,,Blanks,77
+Middlesex,Chelmsford,9,U.S. House,3,,Blanks,109
+Middlesex,Chelmsford,TOTAL,U.S. House,3,,Blanks,755
+Middlesex,Chelmsford,1,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1488
+Middlesex,Chelmsford,2,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1478
+Middlesex,Chelmsford,3,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1574
+Middlesex,Chelmsford,4,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1428
+Middlesex,Chelmsford,5,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1526
+Middlesex,Chelmsford,6,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1639
+Middlesex,Chelmsford,7,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1683
+Middlesex,Chelmsford,8,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1546
+Middlesex,Chelmsford,9,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,1612
+Middlesex,Chelmsford,TOTAL,Councillor,3,Democratic,MARILYN M. PETITTO DEVANEY,13974
+Middlesex,Chelmsford,1,Councillor,3,,All Others,27
+Middlesex,Chelmsford,2,Councillor,3,,All Others,18
+Middlesex,Chelmsford,3,Councillor,3,,All Others,28
+Middlesex,Chelmsford,4,Councillor,3,,All Others,31
+Middlesex,Chelmsford,5,Councillor,3,,All Others,29
+Middlesex,Chelmsford,6,Councillor,3,,All Others,34
+Middlesex,Chelmsford,7,Councillor,3,,All Others,24
+Middlesex,Chelmsford,8,Councillor,3,,All Others,15
+Middlesex,Chelmsford,9,Councillor,3,,All Others,34
+Middlesex,Chelmsford,TOTAL,Councillor,3,,All Others,240
+Middlesex,Chelmsford,1,Councillor,3,,Blanks,706
+Middlesex,Chelmsford,2,Councillor,3,,Blanks,533
+Middlesex,Chelmsford,3,Councillor,3,,Blanks,698
+Middlesex,Chelmsford,4,Councillor,3,,Blanks,599
+Middlesex,Chelmsford,5,Councillor,3,,Blanks,689
+Middlesex,Chelmsford,6,Councillor,3,,Blanks,724
+Middlesex,Chelmsford,7,Councillor,3,,Blanks,782
+Middlesex,Chelmsford,8,Councillor,3,,Blanks,702
+Middlesex,Chelmsford,9,Councillor,3,,Blanks,797
+Middlesex,Chelmsford,TOTAL,Councillor,3,,Blanks,6228
+Middlesex,Chelmsford,1,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1372
+Middlesex,Chelmsford,2,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1394
+Middlesex,Chelmsford,3,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1480
+Middlesex,Chelmsford,4,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1315
+Middlesex,Chelmsford,5,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1377
+Middlesex,Chelmsford,6,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1530
+Middlesex,Chelmsford,7,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1555
+Middlesex,Chelmsford,8,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1435
+Middlesex,Chelmsford,9,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,1448
+Middlesex,Chelmsford,TOTAL,State Senate,3rd Middlesex,Democratic,MICHAEL J. BARRETT,12906
+Middlesex,Chelmsford,1,State Senate,3rd Middlesex,,All Others,2
+Middlesex,Chelmsford,2,State Senate,3rd Middlesex,,All Others,13
+Middlesex,Chelmsford,3,State Senate,3rd Middlesex,,All Others,26
+Middlesex,Chelmsford,4,State Senate,3rd Middlesex,,All Others,30
+Middlesex,Chelmsford,5,State Senate,3rd Middlesex,,All Others,33
+Middlesex,Chelmsford,6,State Senate,3rd Middlesex,,All Others,29
+Middlesex,Chelmsford,7,State Senate,3rd Middlesex,,All Others,26
+Middlesex,Chelmsford,8,State Senate,3rd Middlesex,,All Others,16
+Middlesex,Chelmsford,9,State Senate,3rd Middlesex,,All Others,29
+Middlesex,Chelmsford,TOTAL,State Senate,3rd Middlesex,,All Others,204
+Middlesex,Chelmsford,1,State Senate,3rd Middlesex,,Blanks,847
+Middlesex,Chelmsford,2,State Senate,3rd Middlesex,,Blanks,622
+Middlesex,Chelmsford,3,State Senate,3rd Middlesex,,Blanks,792
+Middlesex,Chelmsford,4,State Senate,3rd Middlesex,,Blanks,713
+Middlesex,Chelmsford,5,State Senate,3rd Middlesex,,Blanks,834
+Middlesex,Chelmsford,6,State Senate,3rd Middlesex,,Blanks,838
+Middlesex,Chelmsford,7,State Senate,3rd Middlesex,,Blanks,908
+Middlesex,Chelmsford,8,State Senate,3rd Middlesex,,Blanks,812
+Middlesex,Chelmsford,9,State Senate,3rd Middlesex,,Blanks,966
+Middlesex,Chelmsford,TOTAL,State Senate,3rd Middlesex,,Blanks,7332
+Middlesex,Chelmsford,1,State House,14th Middlesex,Democratic,COREY ATKINS,1027
+Middlesex,Chelmsford,9,State House,14th Middlesex,Democratic,COREY ATKINS,1113
+Middlesex,Chelmsford,TOTAL,State House,14th Middlesex,Democratic,COREY ATKINS,2140
+Middlesex,Chelmsford,1,State House,14th Middlesex,Republican,HELEN BRADY,948
+Middlesex,Chelmsford,9,State House,14th Middlesex,Republican,HELEN BRADY,1070
+Middlesex,Chelmsford,TOTAL,State House,14th Middlesex,Republican,HELEN BRADY,2018
+Middlesex,Chelmsford,1,State House,14th Middlesex,Green-Rainbow,DANIEL L. FACTOR,93
+Middlesex,Chelmsford,9,State House,14th Middlesex,Green-Rainbow,DANIEL L. FACTOR,90
+Middlesex,Chelmsford,TOTAL,State House,14th Middlesex,Green-Rainbow,DANIEL L. FACTOR,183
+Middlesex,Chelmsford,1,State House,14th Middlesex,,All Others,0
+Middlesex,Chelmsford,9,State House,14th Middlesex,,All Others,9
+Middlesex,Chelmsford,TOTAL,State House,14th Middlesex,,All Others,9
+Middlesex,Chelmsford,1,State House,14th Middlesex,,Blanks,153
+Middlesex,Chelmsford,9,State House,14th Middlesex,,Blanks,161
+Middlesex,Chelmsford,TOTAL,State House,14th Middlesex,,Blanks,314
+Middlesex,Chelmsford,2,State House,16th Middlesex,Democratic,THOMAS A. GOLDEN, JR.,1518
+Middlesex,Chelmsford,3,State House,16th Middlesex,Democratic,THOMAS A. GOLDEN, JR.,1626
+Middlesex,Chelmsford,6,State House,16th Middlesex,Democratic,THOMAS A. GOLDEN, JR.,1728
+Middlesex,Chelmsford,TOTAL,State House,16th Middlesex,Democratic,THOMAS A. GOLDEN, JR.,4872
+Middlesex,Chelmsford,2,State House,16th Middlesex,,All Others,17
+Middlesex,Chelmsford,3,State House,16th Middlesex,,All Others,27
+Middlesex,Chelmsford,6,State House,16th Middlesex,,All Others,32
+Middlesex,Chelmsford,TOTAL,State House,16th Middlesex,,All Others,78
+Middlesex,Chelmsford,2,State House,16th Middlesex,,Blanks,494
+Middlesex,Chelmsford,3,State House,16th Middlesex,,Blanks,645
+Middlesex,Chelmsford,6,State House,16th Middlesex,,Blanks,637
+Middlesex,Chelmsford,TOTAL,State House,16th Middlesex,,Blanks,1776
+Middlesex,Chelmsford,4,State House,17th Middlesex,Democratic,DAVID M. NANGLE,1474
+Middlesex,Chelmsford,TOTAL,State House,17th Middlesex,Democratic,DAVID M. NANGLE,1474
+Middlesex,Chelmsford,4,State House,17th Middlesex,,All Others,26
+Middlesex,Chelmsford,TOTAL,State House,17th Middlesex,,All Others,26
+Middlesex,Chelmsford,4,State House,17th Middlesex,,Blanks,558
+Middlesex,Chelmsford,TOTAL,State House,17th Middlesex,,Blanks,558
+Middlesex,Chelmsford,5,State House,2nd Middlesex,Democratic,JAMES ARCIERO,1557
+Middlesex,Chelmsford,7,State House,2nd Middlesex,Democratic,JAMES ARCIERO,1706
+Middlesex,Chelmsford,8,State House,2nd Middlesex,Democratic,JAMES ARCIERO,1586
+Middlesex,Chelmsford,TOTAL,State House,2nd Middlesex,Democratic,JAMES ARCIERO,4849
+Middlesex,Chelmsford,5,State House,2nd Middlesex,,All Others,35
+Middlesex,Chelmsford,7,State House,2nd Middlesex,,All Others,24
+Middlesex,Chelmsford,8,State House,2nd Middlesex,,All Others,9
+Middlesex,Chelmsford,TOTAL,State House,2nd Middlesex,,All Others,68
+Middlesex,Chelmsford,5,State House,2nd Middlesex,,Blanks,652
+Middlesex,Chelmsford,7,State House,2nd Middlesex,,Blanks,759
+Middlesex,Chelmsford,8,State House,2nd Middlesex,,Blanks,668
+Middlesex,Chelmsford,TOTAL,State House,2nd Middlesex,,Blanks,2079


### PR DESCRIPTION
Data captured from https://github.com/openelections/openelections-sources-ma/blob/master/2016/20161108_ma_general_chelmsfordOfficial%20Results.pdf.