### PR TITLE
parsers: pass html.parser to BeautifulSoup explicitly

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 def parse_president(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:1/stage:General/show_details:1"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     president_candidates = []
     election_links = []
     districts = {}
@@ -48,7 +48,7 @@ def parse_president(year):
 def parse_governor(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:3/stage:General/show_details:1"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     president_candidates = []
     election_links = []
     districts = {}
@@ -89,7 +89,7 @@ def parse_governor(year):
 def parse_us_senate(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:6/stage:General"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -125,7 +125,7 @@ def parse_us_senate(year):
 def parse_secretary(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:45/stage:General"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -161,7 +161,7 @@ def parse_secretary(year):
 def parse_treasurer(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:53/stage:General"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -197,7 +197,7 @@ def parse_treasurer(year):
 def parse_auditor(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:90/stage:General"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -233,7 +233,7 @@ def parse_auditor(year):
 def parse_attorney_general(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:12/stage:General"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -269,7 +269,7 @@ def parse_attorney_general(year):
 def parse_council(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:529/stage:General"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -311,7 +311,7 @@ def parse_council(year):
 def parse_us_house(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:5/stage:General"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -397,7 +397,7 @@ def parse_state_senate(year):
 def parse_state_house(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:8/stage:General"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}

--- a/primary_parser.py
+++ b/primary_parser.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 def parse_president(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:1/stage:Primaries"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     president_candidates = []
     election_links = []
     table = soup.find('table', id="search_results_table")
@@ -50,7 +50,7 @@ def parse_president(year):
 def parse_governor(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:3/stage:Primaries/show_details:1"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     president_candidates = []
     election_links = []
     districts = {}
@@ -98,7 +98,7 @@ def parse_governor(year):
 def parse_us_senate(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:6/stage:Primaries"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -141,7 +141,7 @@ def parse_us_senate(year):
 def parse_secretary(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:45/stage:Primaries"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -184,7 +184,7 @@ def parse_secretary(year):
 def parse_treasurer(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:53/stage:Primaries"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -227,7 +227,7 @@ def parse_treasurer(year):
 def parse_auditor(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:90/stage:Primaries"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -270,7 +270,7 @@ def parse_auditor(year):
 def parse_attorney_general(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:12/stage:Primaries"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -313,7 +313,7 @@ def parse_attorney_general(year):
 def parse_council(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:529/stage:Primaries"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -361,7 +361,7 @@ def parse_council(year):
 def parse_us_house(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:5/stage:Primaries"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}
@@ -409,7 +409,7 @@ def parse_us_house(year):
 def parse_state_senate(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:9/stage:Primaries"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_senate_candidates = []
     election_links = []
     districts = {}
@@ -460,7 +460,7 @@ def parse_state_senate(year):
 def parse_state_house(year):
     url = "http://electionstats.state.ma.us/elections/search/year_from:" + year + "/year_to:" + year + "/office_id:8/stage:Primaries"
     r = requests.get(url)
-    soup = BeautifulSoup(r.text)
+    soup = BeautifulSoup(r.text, "html.parser")
     state_house_candidates = []
     election_links = []
     districts = {}


### PR DESCRIPTION
Every \`BeautifulSoup(r.text)\` call triggers a \`GuessedAtParserWarning\` because bs4 prefers an explicit parser argument. Passed \`\"html.parser\"\` (which bs4 already picks on every system that ships only the stdlib parser) so the scripts don't print 22 warnings per run.

No behavior change — bs4 was selecting \`html.parser\` anyway, this just stops it from complaining about the choice.

closes #30